### PR TITLE
Node v16 Upgrade

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -1,6 +1,7 @@
 name: WIP Test the Action
 
 on:
+  workflow_dispatch:
   push:
     branches: [ main ]
 

--- a/action.yml
+++ b/action.yml
@@ -19,5 +19,5 @@ inputs:
     required: true
     default: 'us-east-2'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR updates the action to use Node 16. Node 12 [is being EOL'd for github actions tomorrow](https://github.blog/changelog/2023-06-13-github-actions-all-actions-will-run-on-node16-instead-of-node12-by-default/).