### PR TITLE
AARP-235 add state encryption to nonprod example project

### DIFF
--- a/.github/workflows/wip.yml
+++ b/.github/workflows/wip.yml
@@ -12,13 +12,25 @@ jobs:
     steps:
     - uses: actions/checkout@v5.0.0
 
-    - name: Setup Terraform 🧱
+    - name: Setup Tofu 🧱
       uses: opentofu/setup-opentofu@v1
+
+    - name: Apply IaC Changes for Tech Demo Example 🧱
+      env:
+        AWS_ACCESS_KEY_ID: ${{ secrets.TF_KEY_ADO_NONPROD }}
+        AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_SECRET_ADO_NONPROD }}
+        TF_VAR_local_state_passphrase: ${{ secrets.TF_LOCAL_STATE_ENCRYPTION_KEY_2025_07 }}
+      run: |
+        cd iac/
+        tofu init
+        tofu plan
+        tofu apply -auto-approve
 
     - name: Outputs 🧱
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.TF_KEY_ADO_NONPROD }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_SECRET_ADO_NONPROD }}
+        TF_VAR_local_state_passphrase: ${{ secrets.TF_LOCAL_STATE_ENCRYPTION_KEY_2025_07 }}
       run: |
         cd iac/
         tofu init
@@ -32,9 +44,11 @@ jobs:
       env:
         AWS_ACCESS_KEY_ID: ${{ secrets.TF_KEY_ADO_NONPROD }}
         AWS_SECRET_ACCESS_KEY: ${{ secrets.TF_SECRET_ADO_NONPROD }}
+        TF_VAR_local_state_passphrase: ${{ secrets.TF_LOCAL_STATE_ENCRYPTION_KEY_2025_07 }}
       with:
         to: ssm
         tf-module-path: iac/
+        tool: 'tofu'
         secret-values: |
           {
             "jasonTest": "${{ secrets.jasonTest }}",

--- a/iac/.terraform.lock.hcl
+++ b/iac/.terraform.lock.hcl
@@ -1,20 +1,18 @@
-# This file is maintained automatically by "terraform init".
+# This file is maintained automatically by "tofu init".
 # Manual edits may be lost in future updates.
 
-provider "registry.terraform.io/hashicorp/aws" {
+provider "registry.opentofu.org/hashicorp/aws" {
   version = "3.50.0"
   hashes = [
-    "h1:05jhjEj3Yk6hR9uhGyPGHTz/NyHYFNwcN/ywxWFGD/U=",
-    "zh:11d5508e180b93ab06935dbebefb08745c78ebfe1ec41d53b4340fb7f27d32eb",
-    "zh:192ae31ddf1c5c4ed7f64a15c8cf3f1a440b1427fa15604e90eee40037973f0a",
-    "zh:2f381b6aec131b468409416ffa1a23a15e70f2e64a554bf47da13d499a30e7e2",
-    "zh:5d7457d0ef1dfe65fbfa89bdddd4132cab728384c99950e2ac2f0c27d0c3ed34",
-    "zh:6d0067f4bc0d0f16ab9c1143cc6817876e5258504e4893070504cd1559758227",
-    "zh:8398b8b872173ce9c9144e81c50ed1a3d5904afac50d6431b970a82534a1f1f4",
-    "zh:adbe50b8504cc0929cd54a945a0509ff2a72ebf790137b492c647314a2d2512a",
-    "zh:b518a91608fcba26fbbc73121373129b4ac7a4544d983ac922a8dc249702f86d",
-    "zh:d208c00f9e52b8accdc1b1f8466789e12491cf3129e849e2ba28427a1f86ba59",
-    "zh:db61d71857e44aa2d3bb3f6ad568c531cb6e2a6b830d8672b46021c5bb194ef1",
-    "zh:eac7aad200f4df951dd30ec8547b9412909c8dc450c1322b28619499e5e2bdbe",
+    "h1:w7OxiMA8T3SAf6eonWtYV6b3tDDGMCE3CwA83a4i34Q=",
+    "zh:011b500a173012f6c42c30b9db24fec9ff99d2b5112e467e269ca659623b487a",
+    "zh:0b65099bc98e19a50868f26d9ff30df0b3a79e687c07a65a375815a277964866",
+    "zh:350e66986aba5ec5494b8a2de1c07b9dc4b44c698703eaf4e0404554988a4ef0",
+    "zh:89b1a8cb4b21a59d4c9634a60cc1ae0b813842dac85690c1b2322f39e1038698",
+    "zh:944a50005dd58f53fbf74739e54095ca54f3a6587ad068ad7b32bce1eee2e9ac",
+    "zh:9c192a751696b6798225cdd91f117056181225a69c98c9101b7bdfe5ee194983",
+    "zh:adfcb4354d741247f1be65f21b362cae70cab6ccf5de1ebaf2d31e287c10e8ee",
+    "zh:c5fc0b11c522893317ddb1ae845f03e663bb0e534b8ed1f474bdea11738b10dd",
+    "zh:e350afd193e9f264bd00f812749cc7addb1d2ee3d7dc8bc192e90ac184c8a70c",
   ]
 }

--- a/iac/state-encryption.tf
+++ b/iac/state-encryption.tf
@@ -1,0 +1,49 @@
+variable "local_state_passphrase" {
+    sensitive   = true
+    type        = string
+    nullable    = false
+    description = "Passphrase for this module's state encryption"
+
+    validation {
+        condition = length(var.local_state_passphrase) == 32
+        error_message = "AES-GCM key should be 32 bytes"
+    }
+}
+
+terraform {
+    encryption {
+        key_provider "pbkdf2" "local_state_passphrase" {
+            passphrase    = var.local_state_passphrase
+            key_length    = 32
+            iterations    = 600000
+            salt_length   = 32
+            hash_function = "sha512"
+        }
+
+        method "aes_gcm" "local-state-encryption" {
+            keys = key_provider.pbkdf2.local_state_passphrase
+        }
+
+        method "unencrypted" "migrate" {
+            # Used as a fallback for the initial state of a previously-unencrypted project.
+            # This does not need to be included for brand-new projects that start out encrypted.
+        }
+
+        # This is YOUR module's state.
+        state {
+            method = method.aes_gcm.local-state-encryption
+
+            # Only needed for a pre-existing Terraform project, which has an unencrypted state file.
+            # Once this has run for every environment, the fallback can be removed, and the
+            # enforced = true option can be enabled.
+            fallback {
+                method = method.unencrypted.migrate
+            }
+
+            # Enable this when all envs have been moved to encrypted state. It prevents accidentally writing
+            # an unencrypted state file, if the passphrase var is unset for some reason.
+            #
+            # enforced = true
+        }
+    }
+}

--- a/iac/versions.tf
+++ b/iac/versions.tf
@@ -1,4 +1,4 @@
 
 terraform {
-  required_version = ">= 1.0.0"
+  required_version = ">= 1.10.6"
 }


### PR DESCRIPTION
update the ado-nonprod tech-demo example's terraform lockfile to use opentofu add state-encryption. update the pipeline to use the local passphrase to run `tofu` steps on encrypted state (also add `apply` step so there is a mechanism for the state encryption to occur). 